### PR TITLE
recompose: Enable correct typing for nested StateHandlers

### DIFF
--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -137,8 +137,8 @@ declare module 'recompose' {
     type StateHandlerMap<TState> = {
       [updaterName: string]: StateHandler<TState>;
     };
-    type StateUpdaters<TOutter, TState, TUpdaters> = {
-      [updaterName in keyof TUpdaters]: (state: TState, props: TOutter) => StateHandler<TState>;
+    type StateUpdaters<TOutter, TState, TUpdaters extends StateHandlerMap<TState>> = {
+      [updaterName in keyof TUpdaters]: (state: TState, props: TOutter) => TUpdaters[updaterName];
     };
     export function withStateHandlers<TState, TUpdaters extends StateHandlerMap<TState>, TOutter = {}>(
       createProps: TState | mapper<TOutter, TState>,


### PR DESCRIPTION
The StateUpdaters did not transport the actual StateHandler type when using withStateHandlers. This made arguments and return values for StateHandlers any. 

By using the actual type reference on StateUpdaters, the type for each handler is inferred correctly.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/acdlite/recompose/blob/master/docs/API.md#withstatehandlers
- [x] Increase the version number in the header if appropriate.

